### PR TITLE
HardwareButtons: send signals for volume up and down buttons

### DIFF
--- a/src/extensions/cutie-shell.h
+++ b/src/extensions/cutie-shell.h
@@ -17,8 +17,15 @@ class CutieShell : public QWaylandCompositorExtensionTemplate<CutieShell>,
 {
 	Q_OBJECT
     public:
-	enum SpecialKey : uint32_t { POWER_PRESS = 0, POWER_RELEASE = 1 };
-
+	enum SpecialKey : uint32_t {
+		POWER_PRESS = 0,
+		POWER_RELEASE = 1,
+		VOLUME_UP_PRESS = 2,
+		VOLUME_UP_RELEASE = 3,
+		VOLUME_DOWN_PRESS = 4,
+		VOLUME_DOWN_RELEASE = 5
+	};
+	
 	CutieShell(CwlCompositor *compositor);
 	void initialize() override;
 

--- a/src/glwindow.cpp
+++ b/src/glwindow.cpp
@@ -182,6 +182,14 @@ void GlWindow::keyPressEvent(QKeyEvent *event)
 	if (event->key() == Qt::Key_PowerOff)
 		m_cwlcompositor->specialKey(
 			CutieShell::SpecialKey::POWER_PRESS);
+
+	if (event->key() == Qt::Key_VolumeUp)
+		m_cwlcompositor->specialKey(
+			CutieShell::SpecialKey::VOLUME_UP_PRESS);
+
+	if (event->key() == Qt::Key_VolumeDown)
+		m_cwlcompositor->specialKey(
+			CutieShell::SpecialKey::VOLUME_DOWN_PRESS);		
 }
 
 void GlWindow::keyReleaseEvent(QKeyEvent *event)
@@ -189,4 +197,12 @@ void GlWindow::keyReleaseEvent(QKeyEvent *event)
 	if (event->key() == Qt::Key_PowerOff)
 		m_cwlcompositor->specialKey(
 			CutieShell::SpecialKey::POWER_RELEASE);
+
+	if (event->key() == Qt::Key_VolumeUp)
+		m_cwlcompositor->specialKey(
+			CutieShell::SpecialKey::VOLUME_UP_RELEASE);
+
+	if (event->key() == Qt::Key_VolumeDown)
+		m_cwlcompositor->specialKey(
+			CutieShell::SpecialKey::VOLUME_DOWN_RELEASE);
 }

--- a/src/protocols/cutie-shell-private.xml
+++ b/src/protocols/cutie-shell-private.xml
@@ -49,6 +49,10 @@
 
         <entry name="power_press" value="0" summary="the power key pressed"/>
         <entry name="power_release" value="1" summary="the power key released"/>
+        <entry name="volume_up_press" value="2" summary="the volume up key pressed"/>
+        <entry name="volume_up_release" value="3" summary="the volume up released"/>
+        <entry name="volume_down_press" value="4" summary="the volume down key pressed"/>
+        <entry name="volume_down_release" value="5" summary="the volume down released"/>
       </enum>
 
       <event name="thumbnail_damage">


### PR DESCRIPTION
Send press and release signals to the shell for both volume up and volume down buttons

This will allow cutie panel to change volume based on button presses

part 2: https://github.com/cutie-shell/cutie-panel/pull/8
