### PR TITLE
fix improper display size reporting when running nested 

### DIFF
--- a/src/cutie-wlc.cpp
+++ b/src/cutie-wlc.cpp
@@ -12,42 +12,44 @@
 #include <QTouchEvent>
 #include <QOpenGLFramebufferObject>
 #include <QOpenGLTexture>
+#include <QProcess>
+#include <QDebug>
 
 CwlCompositor::CwlCompositor(GlWindow *glwindow)
-	: m_glwindow(glwindow)
-	, m_xdgShell(new QWaylandXdgShell(this))
-	, m_layerShell(new LayerShellV1(this))
-	, m_xdgdecoration(new QWaylandXdgDecorationManagerV1())
+    : m_glwindow(glwindow)
+    , m_xdgShell(new QWaylandXdgShell(this))
+    , m_layerShell(new LayerShellV1(this))
+    , m_xdgdecoration(new QWaylandXdgDecorationManagerV1())
 {
-	m_glwindow->setCompositor(this);
-	connect(m_glwindow, &GlWindow::glReady, this, &CwlCompositor::create);
+    m_glwindow->setCompositor(this);
+    connect(m_glwindow, &GlWindow::glReady, this, &CwlCompositor::create);
 
-	connect(m_xdgShell, &QWaylandXdgShell::toplevelCreated, this,
-		&CwlCompositor::onXdgToplevelCreated);
-	connect(m_xdgShell, &QWaylandXdgShell::popupCreated, this,
-		&CwlCompositor::onXdgPopupCreated);
-	connect(m_layerShell, &LayerShellV1::layerShellSurfaceCreated, this,
-		&CwlCompositor::onLayerShellSurfaceCreated);
+    connect(m_xdgShell, &QWaylandXdgShell::toplevelCreated, this,
+        &CwlCompositor::onXdgToplevelCreated);
+    connect(m_xdgShell, &QWaylandXdgShell::popupCreated, this,
+        &CwlCompositor::onXdgPopupCreated);
+    connect(m_layerShell, &LayerShellV1::layerShellSurfaceCreated, this,
+        &CwlCompositor::onLayerShellSurfaceCreated);
 
-	blurAnim->setDuration(250);
-	unblurAnim->setDuration(250);
-	launcherOpenAnim->setDuration(250);
-	launcherCloseAnim->setDuration(250);
-	blurAnim->setEndValue(1.0);
-	unblurAnim->setEndValue(0.0);
-	launcherOpenAnim->setEndValue(1.0);
-	launcherCloseAnim->setEndValue(0.0);
+    blurAnim->setDuration(250);
+    unblurAnim->setDuration(250);
+    launcherOpenAnim->setDuration(250);
+    launcherCloseAnim->setDuration(250);
+    blurAnim->setEndValue(1.0);
+    unblurAnim->setEndValue(0.0);
+    launcherOpenAnim->setEndValue(1.0);
+    launcherCloseAnim->setEndValue(0.0);
 
-	connect(blurAnim, &QVariantAnimation::valueChanged, this,
-		&CwlCompositor::animationValueChanged);
-	connect(unblurAnim, &QVariantAnimation::valueChanged, this,
-		&CwlCompositor::animationValueChanged);
-	connect(unblurAnim, &QVariantAnimation::finished, this,
-		[this]() { m_workspace->showDesktop(true); });
-	connect(launcherOpenAnim, &QVariantAnimation::valueChanged, this,
-		&CwlCompositor::animationValueChanged);
-	connect(launcherCloseAnim, &QVariantAnimation::valueChanged, this,
-		&CwlCompositor::animationValueChanged);
+    connect(blurAnim, &QVariantAnimation::valueChanged, this,
+        &CwlCompositor::animationValueChanged);
+    connect(unblurAnim, &QVariantAnimation::valueChanged, this,
+        &CwlCompositor::animationValueChanged);
+    connect(unblurAnim, &QVariantAnimation::finished, this,
+        [this]() { m_workspace->showDesktop(true); });
+    connect(launcherOpenAnim, &QVariantAnimation::valueChanged, this,
+        &CwlCompositor::animationValueChanged);
+    connect(launcherCloseAnim, &QVariantAnimation::valueChanged, this,
+        &CwlCompositor::animationValueChanged);
 }
 
 CwlCompositor::~CwlCompositor()
@@ -56,41 +58,50 @@ CwlCompositor::~CwlCompositor()
 
 void CwlCompositor::create()
 {
-	m_output = new QWaylandOutput(this, m_glwindow);
-	QWaylandOutputMode mode(m_glwindow->size(), 60000);
-	m_output->addMode(mode, true);
-	QWaylandCompositor::create();
-	m_output->setCurrentMode(mode);
-	m_output->setScaleFactor(m_scaleFactor);
+    // --- Fallback for 0,0 geometry ---
+    QSize windowSize = m_glwindow->size();
+    if (windowSize.width() <= 0 || windowSize.height() <= 0) {
+        windowSize = QSize(720, 1280);
+    }
 
-	m_xdgdecoration->setExtensionContainer(this);
-	m_xdgdecoration->initialize();
-	m_xdgdecoration->setPreferredMode(
-		QWaylandXdgToplevel::ServerSideDecoration);
+    // --- Ensure scale is never 0 ---
+    if (m_scaleFactor < 1) m_scaleFactor = 1;
 
-	m_workspace = new CwlWorkspace(this);
-	m_cutieshell = new CutieShell(this);
-	m_outputManager = new OutputManagerV1(this);
-	m_outputPowerManager = new OutputPowerManagerV1(this);
-	m_screencopyManager = new ScreencopyManagerV1(this);
+    m_output = new QWaylandOutput(this, m_glwindow);
+    QWaylandOutputMode mode(windowSize, 60000);
+    m_output->addMode(mode, true);
+    QWaylandCompositor::create();
+    m_output->setCurrentMode(mode);
+    m_output->setScaleFactor(m_scaleFactor);
 
-	m_foreignTlManagerV1 = new ForeignToplevelManagerV1(this);
-	connect(m_workspace, &CwlWorkspace::toplevelCreated,
-		m_foreignTlManagerV1,
-		&ForeignToplevelManagerV1::onToplevelCreated);
-	connect(m_workspace, &CwlWorkspace::toplevelDestroyed,
-		m_foreignTlManagerV1,
-		&ForeignToplevelManagerV1::onToplevelDestroyed);
+    m_xdgdecoration->setExtensionContainer(this);
+    m_xdgdecoration->initialize();
+    m_xdgdecoration->setPreferredMode(
+        QWaylandXdgToplevel::ServerSideDecoration);
 
-	initInputMethod();
+    m_workspace = new CwlWorkspace(this);
+    m_cutieshell = new CutieShell(this);
+    m_outputManager = new OutputManagerV1(this);
+    m_outputPowerManager = new OutputPowerManagerV1(this);
+    m_screencopyManager = new ScreencopyManagerV1(this);
 
-	qputenv("CUTIE_SHELL", QByteArray("true"));
-	qputenv("QT_QPA_PLATFORM", QByteArray("wayland"));
-	qputenv("EGL_PLATFORM", QByteArray("wayland"));
-	qputenv("QT_IM_MODULE", QByteArray("textinputv3"));
-	qunsetenv("QT_QPA_GENERIC_PLUGINS");
-	qunsetenv("QT_SCALE_FACTOR");
-	qputenv("WAYLAND_DISPLAY", socketName());
+    m_foreignTlManagerV1 = new ForeignToplevelManagerV1(this);
+    connect(m_workspace, &CwlWorkspace::toplevelCreated,
+        m_foreignTlManagerV1,
+        &ForeignToplevelManagerV1::onToplevelCreated);
+    connect(m_workspace, &CwlWorkspace::toplevelDestroyed,
+        m_foreignTlManagerV1,
+        &ForeignToplevelManagerV1::onToplevelDestroyed);
+
+    initInputMethod();
+
+    qputenv("CUTIE_SHELL", QByteArray("true"));
+    qputenv("QT_QPA_PLATFORM", QByteArray("wayland"));
+    qputenv("EGL_PLATFORM", QByteArray("wayland"));
+    qputenv("QT_IM_MODULE", QByteArray("textinputv3"));
+    qunsetenv("QT_QPA_GENERIC_PLUGINS");
+    qunsetenv("QT_SCALE_FACTOR");
+    qputenv("WAYLAND_DISPLAY", socketName());
 
 	/*
 		Setting QSG_NO_VSYNC and QSG_RENDER_LOOP makes resizing QtQuick apps
@@ -99,181 +110,181 @@ void CwlCompositor::create()
 
 		Might also be the hwcomposer issue https://doc.qt.io/qt-6/qtquick-visualcanvas-scenegraph.html
 	*/
-	qputenv("QSG_NO_VSYNC", QByteArray("1"));
-	qputenv("QSG_RENDER_LOOP", QByteArray("basic"));
+    qputenv("QSG_NO_VSYNC", QByteArray("1"));
+    qputenv("QSG_RENDER_LOOP", QByteArray("basic"));
 
-	QStringList args = QStringList();
-	args.append("-c");
-	args.append("cutie-home");
-	if (!QProcess::startDetached("bash", args))
-		qDebug() << "Failed to run";
+    QStringList args = QStringList();
+    args.append("-c");
+    args.append("cutie-home");
+    if (!QProcess::startDetached("bash", args))
+        qDebug() << "Failed to run";
 
-	args = QStringList();
-	args.append("-c");
-	args.append(launcher);
-	if (!QProcess::startDetached("bash", args))
-		qDebug() << "Failed to run";
+    args = QStringList();
+    args.append("-c");
+    args.append(launcher);
+    if (!QProcess::startDetached("bash", args))
+        qDebug() << "Failed to run";
 
-	args = QStringList();
-	args.append("-c");
-	args.append("cutie-panel");
-	if (!QProcess::startDetached("bash", args))
-		qDebug() << "Failed to run";
+    args = QStringList();
+    args.append("-c");
+    args.append("cutie-panel");
+    if (!QProcess::startDetached("bash", args))
+        qDebug() << "Failed to run";
 
-	args = QStringList();
-	args.append("-c");
-	args.append("cutie-keyboard");
-	if (!QProcess::startDetached("bash", args))
-		qDebug() << "Failed to run";
+    args = QStringList();
+    args.append("-c");
+    args.append("cutie-keyboard");
+    if (!QProcess::startDetached("bash", args))
+        qDebug() << "Failed to run";
 
-	args = QStringList();
-	args.append("-c");
-	args.append("env XDG_CURRENT_DESKTOP=GNOME /usr/libexec/feedbackd");
-	if (!QProcess::startDetached("bash", args))
-		qDebug() << "Failed to run";
+    args = QStringList();
+    args.append("-c");
+    args.append("env XDG_CURRENT_DESKTOP=GNOME /usr/libexec/feedbackd");
+    if (!QProcess::startDetached("bash", args))
+        qDebug() << "Failed to run";
 
-	args = QStringList();
-	args.append("-c");
-	args.append("loginctl activate");
-	if (!QProcess::startDetached("bash", args))
-		qDebug() << "Failed to run";
+    args = QStringList();
+    args.append("-c");
+    args.append("loginctl activate");
+    if (!QProcess::startDetached("bash", args))
+        qDebug() << "Failed to run";
 }
 
 QList<CwlView *> CwlCompositor::getViews() const
 {
-	return m_workspace->getViews();
+    return m_workspace->getViews();
 }
 
 QList<CwlView *> CwlCompositor::getToplevelViews()
 {
-	return m_workspace->getToplevelViews();
+    return m_workspace->getToplevelViews();
 }
 
 CwlView *CwlCompositor::viewAt(const QPoint &position)
 {
-	CwlView *ret = nullptr;
-	for (auto it = getViews().crbegin(); it != getViews().crend(); ++it) {
-		CwlView *view = *it;
+    CwlView *ret = nullptr;
+    for (auto it = getViews().crbegin(); it != getViews().crend(); ++it) {
+        CwlView *view = *it;
 		QRectF geom(view->getPosition(), view->size() * scaleFactor());
-		QPoint checkPoint = position;
+        QPoint checkPoint = position;
 
-		if (view->getAppId() == "cutie-keyboard")
+        if (view->getAppId() == "cutie-keyboard")
 			checkPoint = position / scaleFactor();
 
-		if (geom.contains(checkPoint)) {
-			if (view->getChildViews().size() > 0) {
+        if (geom.contains(checkPoint)) {
+            if (view->getChildViews().size() > 0) {
 				for (CwlView *childView :
 				     view->getChildViews()) {
 					checkPoint = position / scaleFactor();
 					QRectF geom(childView->getPosition(),
 						    childView->size() *
 							    scaleFactor());
-					if (geom.contains(checkPoint)) {
-						ret = childView;
-						return ret;
-					}
-				}
-			}
-			ret = view;
-			return ret;
-		}
-	}
-	return ret;
+                    if (geom.contains(checkPoint)) {
+                        ret = childView;
+                        return ret;
+                    }
+                }
+            }
+            ret = view;
+            return ret;
+        }
+    }
+    return ret;
 }
 
 CwlView *CwlCompositor::findView(QWaylandSurface *s)
 {
-	for (CwlView *view : getViews()) {
-		if (view->surface() == s)
-			return view;
-	}
-	return nullptr;
+    for (CwlView *view : getViews()) {
+        if (view->surface() == s)
+            return view;
+    }
+    return nullptr;
 }
 
 CwlView *CwlCompositor::findTlView(QWaylandSurface *s)
 {
-	CwlView *ret = nullptr;
-	for (CwlView *view : m_workspace->getToplevelViews()) {
-		if (view->surface() == s)
-			ret = view;
-		else if (view->getChildViews().size() > 0)
-			ret = findTreeView(s, view);
-	}
-	return ret;
+    CwlView *ret = nullptr;
+    for (CwlView *view : m_workspace->getToplevelViews()) {
+        if (view->surface() == s)
+            ret = view;
+        else if (view->getChildViews().size() > 0)
+            ret = findTreeView(s, view);
+    }
+    return ret;
 }
 
 CwlView *CwlCompositor::findTreeView(QWaylandSurface *s, CwlView *rootView)
 {
-	CwlView *ret = nullptr;
-	for (CwlView *childView : rootView->getChildViews()) {
-		if (childView->surface() == s)
-			ret = childView;
-		else if (childView->getChildViews().size() > 0)
-			ret = findTreeView(s, childView);
-	}
-	return ret;
+    CwlView *ret = nullptr;
+    for (CwlView *childView : rootView->getChildViews()) {
+        if (childView->surface() == s)
+            ret = childView;
+        else if (childView->getChildViews().size() > 0)
+            ret = findTreeView(s, childView);
+    }
+    return ret;
 }
 
 void CwlCompositor::onXdgToplevelCreated(QWaylandXdgToplevel *toplevel,
-					 QWaylandXdgSurface *xdgSurface)
+                     QWaylandXdgSurface *xdgSurface)
 {
-	CwlView *view = new CwlView(this, m_workspace->availableGeometry());
-	view->setOutput(outputFor(m_glwindow));
-	view->setSurface(xdgSurface->surface());
+    CwlView *view = new CwlView(this, m_workspace->availableGeometry());
+    view->setOutput(outputFor(m_glwindow));
+    view->setSurface(xdgSurface->surface());
 
-	view->setTopLevel(toplevel);
+    view->setTopLevel(toplevel);
 
-	if (m_launcherView != nullptr)
-		launcherCloseAnim->start();
+    if (m_launcherView != nullptr)
+        launcherCloseAnim->start();
 
-	connect(m_workspace, &CwlWorkspace::availableGeometryChanged, view,
-		&CwlView::onAvailableGeometryChanged);
-	connect(view->surface(), &QWaylandSurface::redraw, view,
-		&CwlView::onRedraw);
-	connect(view, &QWaylandView::surfaceDestroyed, this,
-		&CwlCompositor::viewSurfaceDestroyed);
+    connect(m_workspace, &CwlWorkspace::availableGeometryChanged, view,
+        &CwlView::onAvailableGeometryChanged);
+    connect(view->surface(), &QWaylandSurface::redraw, view,
+        &CwlView::onRedraw);
+    connect(view, &QWaylandView::surfaceDestroyed, this,
+        &CwlCompositor::viewSurfaceDestroyed);
 }
 
 void CwlCompositor::initInputMethod()
 {
-	if (m_inputMngr != nullptr)
-		delete m_inputMngr;
+    if (m_inputMngr != nullptr)
+        delete m_inputMngr;
 
-	m_inputMngr = new InputMethodManagerV2(this);
-	connect(m_inputMngr, &InputMethodManagerV2::imDestroyed, this,
-		&CwlCompositor::initInputMethod);
+    m_inputMngr = new InputMethodManagerV2(this);
+    connect(m_inputMngr, &InputMethodManagerV2::imDestroyed, this,
+        &CwlCompositor::initInputMethod);
 }
 
 void CwlCompositor::animationValueChanged(const QVariant &value)
 {
-	triggerRender();
+    triggerRender();
 }
 
 void CwlCompositor::onHideKeyboard()
 {
-	if (m_inputMngr->getInputMethod() != nullptr)
-		m_inputMngr->getInputMethod()->hidePanel();
+    if (m_inputMngr->getInputMethod() != nullptr)
+        m_inputMngr->getInputMethod()->hidePanel();
 }
 
 void CwlCompositor::onXdgPopupCreated(QWaylandXdgPopup *popup,
-				      QWaylandXdgSurface *xdgSurface)
+                      QWaylandXdgSurface *xdgSurface)
 {
-	CwlView *view = new CwlView(this, m_workspace->availableGeometry());
-	view->setOutput(outputFor(m_glwindow));
-	view->setSurface(xdgSurface->surface());
-	view->setPopUp(popup);
+    CwlView *view = new CwlView(this, m_workspace->availableGeometry());
+    view->setOutput(outputFor(m_glwindow));
+    view->setSurface(xdgSurface->surface());
+    view->setPopUp(popup);
 
-	CwlView *parent_view = findTlView(popup->parentXdgSurface()->surface());
+    CwlView *parent_view = findTlView(popup->parentXdgSurface()->surface());
 
-	qDebug() << "Popup " << (uint64_t)view << " created";
+    qDebug() << "Popup " << (uint64_t)view << " created";
 
 	view->setPosition(popup->unconstrainedPosition() +
 			  parent_view->getPosition());
 
-	view->layer = TOP;
+        view->layer = TOP;
 	if (parent_view) {
-		parent_view->addChildView(view);
-		view->setParentView(parent_view);
+        parent_view->addChildView(view);
+        view->setParentView(parent_view);
 		qDebug() << "Popup " << (uint64_t)view << " parented to "
 			 << (uint64_t)parent_view;
 		connect(view->surface(), &QWaylandSurface::redraw, view,
@@ -282,425 +293,429 @@ void CwlCompositor::onXdgPopupCreated(QWaylandXdgPopup *popup,
 			&CwlCompositor::viewSurfaceDestroyed);
 		connect(popup, &QWaylandXdgPopup::configuredGeometryChanged,
 			view, &CwlView::onPopUpGeometryChanged);
-	} else
-		m_workspace->addView(view);
+    } else
+        m_workspace->addView(view);
 }
 
 void CwlCompositor::onLayerShellSurfaceCreated(LayerSurfaceV1 *layerSurface)
 {
-	CwlView *view = new CwlView(this, m_workspace->availableGeometry());
-	view->setOutput(outputFor(m_glwindow));
-	view->setSurface(layerSurface->surface);
+    CwlView *view = new CwlView(this, m_workspace->availableGeometry());
+    view->setOutput(outputFor(m_glwindow));
+    view->setSurface(layerSurface->surface);
 
-	view->setLayerSurface(layerSurface);
-	view->setPosition(QPoint(0, 0));
-	layerSurface->send_configure(0, 0, 0);
+    view->setLayerSurface(layerSurface);
+    view->setPosition(QPoint(0, 0));
+    layerSurface->send_configure(0, 0, 0);
 
-	view->layer = (CwlViewLayer)layerSurface->ls_layer;
-	m_workspace->addView(view);
+    view->layer = (CwlViewLayer)layerSurface->ls_layer;
+    m_workspace->addView(view);
 
-	if (layerSurface->ls_scope == "cutie-home")
-		m_homeView = view;
+    if (layerSurface->ls_scope == "cutie-home")
+        m_homeView = view;
 
-	if (layerSurface->ls_scope == "cutie-panel")
-		m_panelView = view;
-	connect(view->surface(), &QWaylandSurface::redraw, view,
-		&CwlView::onRedraw);
-	connect(view, &QWaylandView::surfaceDestroyed, this,
-		&CwlCompositor::viewSurfaceDestroyed);
-	connect(view->m_layerSurface, &LayerSurfaceV1::layerSurfaceDataChanged,
-		m_workspace, &CwlWorkspace::onLayerSurfaceDataChanged);
-	connect(view->m_layerSurface, &LayerSurfaceV1::hideKeyboard, this,
-		&CwlCompositor::onHideKeyboard);
+    if (layerSurface->ls_scope == "cutie-panel")
+        m_panelView = view;
+    connect(view->surface(), &QWaylandSurface::redraw, view,
+        &CwlView::onRedraw);
+    connect(view, &QWaylandView::surfaceDestroyed, this,
+        &CwlCompositor::viewSurfaceDestroyed);
+    connect(view->m_layerSurface, &LayerSurfaceV1::layerSurfaceDataChanged,
+        m_workspace, &CwlWorkspace::onLayerSurfaceDataChanged);
+    connect(view->m_layerSurface, &LayerSurfaceV1::hideKeyboard, this,
+        &CwlCompositor::onHideKeyboard);
 }
 
 CwlView *CwlCompositor::getHomeView()
 {
-	return m_homeView;
+    return m_homeView;
 }
 
 CwlView *CwlCompositor::getTopPanel()
 {
-	return m_panelView;
+    return m_panelView;
 }
 
 void CwlCompositor::raise(CwlView *view)
 {
-	m_workspace->raiseView(view);
+    m_workspace->raiseView(view);
 
-	if (view->isHidden())
-		view->setHidden(false);
+    if (view->isHidden())
+        view->setHidden(false);
 
-	defaultSeat()->setKeyboardFocus(view->surface());
+    defaultSeat()->setKeyboardFocus(view->surface());
 
-	if (view == m_homeView) {
-		m_homeOpen = true;
-		unblurAnim->start();
-	} else {
-		m_homeOpen = false;
-		blurAnim->start();
-	}
+    if (view == m_homeView) {
+        m_homeOpen = true;
+        unblurAnim->start();
+    } else {
+        m_homeOpen = false;
+        blurAnim->start();
+    }
 
-	triggerRender();
+    triggerRender();
 }
 
 void CwlCompositor::handleTouchEvent(QList<QEventPoint> points)
 {
-	CwlView *view = m_launcherView;
-	if (launcherPosition() == 0.0)
-		view = viewAt(points.first().globalPosition().toPoint());
-	if (view == nullptr)
-		return;
-	foreach(QEventPoint point, points) {
-		defaultSeat()->touch()->sendTouchPointEvent(
-			view->surface(), point.id(),
+    CwlView *view = m_launcherView;
+    if (launcherPosition() == 0.0)
+        view = viewAt(points.first().globalPosition().toPoint());
+    if (view == nullptr)
+        return;
+    foreach(QEventPoint point, points) {
+        defaultSeat()->touch()->sendTouchPointEvent(
+            view->surface(), point.id(),
 			point.position() / scaleFactor() - view->getPosition(),
-			(Qt::TouchPointState)point.state());
-	}
-	defaultSeat()->touch()->sendFrameEvent(view->surface()->client());
+            (Qt::TouchPointState)point.state());
+    }
+    defaultSeat()->touch()->sendFrameEvent(view->surface()->client());
 }
 
 void CwlCompositor::handleMouseMoveEvent(QList<QEventPoint> points)
 {
-	CwlView *view = m_launcherView;
-	if (launcherPosition() == 0.0)
-		view = viewAt(points.first().position().toPoint());
-	if (view == nullptr)
-		return;
-	defaultSeat()->sendMouseMoveEvent(
+    CwlView *view = m_launcherView;
+    if (launcherPosition() == 0.0)
+        view = viewAt(points.first().position().toPoint());
+    if (view == nullptr)
+        return;
+    defaultSeat()->sendMouseMoveEvent(
 		view, points.first().position().toPoint() / scaleFactor() -
-			      view->getPosition());
+                  view->getPosition());
 }
 
 void CwlCompositor::handleMousePressEvent(QList<QEventPoint> points,
-					  Qt::MouseButton btn)
+                      Qt::MouseButton btn)
 {
-	handleMouseMoveEvent(points);
-	defaultSeat()->sendMousePressEvent(btn);
+    handleMouseMoveEvent(points);
+    defaultSeat()->sendMousePressEvent(btn);
 }
 
 void CwlCompositor::handleMouseReleaseEvent(QList<QEventPoint> points,
-					    Qt::MouseButton btn)
+                        Qt::MouseButton btn)
 {
-	handleMouseMoveEvent(points);
-	defaultSeat()->sendMouseReleaseEvent(btn);
+    handleMouseMoveEvent(points);
+    defaultSeat()->sendMouseReleaseEvent(btn);
 }
 
 bool CwlCompositor::handleGesture(QPointerEvent *ev, int edge, int corner)
 {
-	if (edge == EDGE_LEFT) {
-		if (ev->isBeginEvent()) {
-			return (launcherPosition() == 0.0) && (blur() != 0.0);
-		}
+    if (edge == EDGE_LEFT) {
+        if (ev->isBeginEvent()) {
+            return (launcherPosition() == 0.0) && (blur() != 0.0);
+        }
 
-		if (ev->isUpdateEvent()) {
-			if ((ev->points().first().globalPosition() -
-			     m_glwindow->gesture()->startingPoint())
-				    .x() > GESTURE_MINIMUM_THRESHOLD) {
-				m_glwindow->gesture()->confirmGesture();
-			}
-			setBlur(1.0 -
-				1.0 * ev->points().first().globalPosition().x() /
-					m_glwindow->width());
-			return true;
-		}
+        if (ev->isUpdateEvent()) {
+            if ((ev->points().first().globalPosition() -
+                 m_glwindow->gesture()->startingPoint())
+                    .x() > GESTURE_MINIMUM_THRESHOLD) {
+                m_glwindow->gesture()->confirmGesture();
+            }
+            setBlur(1.0 -
+                1.0 * ev->points().first().globalPosition().x() /
+                    m_glwindow->width());
+            return true;
+        }
 
-		if (ev->isEndEvent()) {
-			if (ev->points().first().globalPosition().x() >
-			    GESTURE_ACCEPT_THRESHOLD) {
-				raise(m_homeView);
-				return true;
-			}
-			blurAnim->start();
-			m_homeOpen = false;
-			return true;
-		}
-	}
+        if (ev->isEndEvent()) {
+            if (ev->points().first().globalPosition().x() >
+                GESTURE_ACCEPT_THRESHOLD) {
+                raise(m_homeView);
+                return true;
+            }
+            blurAnim->start();
+            m_homeOpen = false;
+            return true;
+        }
+    }
 
-	if (edge == EDGE_RIGHT) {
-		if (ev->isBeginEvent()) {
-			return (launcherPosition() == 0.0) && (blur() != 0.0);
-		}
+    if (edge == EDGE_RIGHT) {
+        if (ev->isBeginEvent()) {
+            return (launcherPosition() == 0.0) && (blur() != 0.0);
+        }
 
-		if (ev->isUpdateEvent()) {
-			if ((-ev->points().first().globalPosition() +
-			     m_glwindow->gesture()->startingPoint())
-				    .x() > GESTURE_MINIMUM_THRESHOLD) {
-				m_glwindow->gesture()->confirmGesture();
-			}
-			setBlur(1.0 *
-				ev->points().first().globalPosition().x() /
-				m_glwindow->width());
-			return true;
-		}
+        if (ev->isUpdateEvent()) {
+            if ((-ev->points().first().globalPosition() +
+                 m_glwindow->gesture()->startingPoint())
+                    .x() > GESTURE_MINIMUM_THRESHOLD) {
+                m_glwindow->gesture()->confirmGesture();
+            }
+            setBlur(1.0 *
+                ev->points().first().globalPosition().x() /
+                m_glwindow->width());
+            return true;
+        }
 
-		if (ev->isEndEvent()) {
-			if (ev->points().first().globalPosition().x() <
-			    m_glwindow->width() - GESTURE_ACCEPT_THRESHOLD) {
-				raise(m_homeView);
-				return true;
-			}
-			blurAnim->start();
-			m_homeOpen = false;
-			return true;
-		}
-	}
+        if (ev->isEndEvent()) {
+            if (ev->points().first().globalPosition().x() <
+                m_glwindow->width() - GESTURE_ACCEPT_THRESHOLD) {
+                raise(m_homeView);
+                return true;
+            }
+            blurAnim->start();
+            m_homeOpen = false;
+            return true;
+        }
+    }
 
-	if (edge == EDGE_BOTTOM) {
-		if (ev->isBeginEvent() || ev->isUpdateEvent()) {
-			if (m_panelView != nullptr)
-				if (m_panelView->panelState > 1)
-					return false;
-			if (m_inputMngr->getInputMethod() != nullptr)
-				if (!m_inputMngr->getInputMethod()
-					     ->isPanelHidden())
-					return false;
-			if ((-ev->points().first().globalPosition() +
-			     m_glwindow->gesture()->startingPoint())
-				    .y() > GESTURE_MINIMUM_THRESHOLD) {
-				m_glwindow->gesture()->confirmGesture();
-				setLauncherPosition(qMin(
-					1.0,
-					1.0 - (ev->points().first()
-							       .globalPosition()
-							       .y() /
-						       scaleFactor() -
-					       m_workspace->outputGeometry()
-						       .y()) /
-							m_workspace
-								->outputGeometry()
-								.height()));
-			}
-			return true;
-		}
+    if (edge == EDGE_BOTTOM) {
+        if (ev->isBeginEvent() || ev->isUpdateEvent()) {
+            if (m_panelView != nullptr)
+                if (m_panelView->panelState > 1)
+                    return false;
+            if (m_inputMngr->getInputMethod() != nullptr)
+                if (!m_inputMngr->getInputMethod()
+                         ->isPanelHidden())
+                    return false;
+            if ((-ev->points().first().globalPosition() +
+                 m_glwindow->gesture()->startingPoint())
+                    .y() > GESTURE_MINIMUM_THRESHOLD) {
+                m_glwindow->gesture()->confirmGesture();
+                setLauncherPosition(qMin(
+                    1.0,
+                    1.0 - (ev->points().first()
+                                   .globalPosition()
+                                   .y() /
+                               scaleFactor() -
+                           m_workspace->outputGeometry()
+                               .y()) /
+                            m_workspace
+                                ->outputGeometry()
+                                .height()));
+            }
+            return true;
+        }
 
-		if (ev->isEndEvent()) {
-			if (m_panelView != nullptr) {
-				if (m_panelView->panelState > 1) {
-					return false;
-				}
-			}
-			if (ev->points().first().globalPosition().y() <
-			    m_glwindow->height() * 0.8)
-				launcherOpenAnim->start();
-			else
-				launcherCloseAnim->start();
-			return true;
-		}
-	}
+        if (ev->isEndEvent()) {
+            if (m_panelView != nullptr) {
+                if (m_panelView->panelState > 1) {
+                    return false;
+                }
+            }
+            if (ev->points().first().globalPosition().y() <
+                m_glwindow->height() * 0.8)
+                launcherOpenAnim->start();
+            else
+                launcherCloseAnim->start();
+            return true;
+        }
+    }
 
-	if (edge == EDGE_TOP) {
-		if (launcherPosition() > 0.0) {
-			if (ev->isBeginEvent() || ev->isUpdateEvent()) {
-				if ((ev->points().first().globalPosition() -
-				     m_glwindow->gesture()->startingPoint())
-					    .y() > GESTURE_MINIMUM_THRESHOLD) {
-					m_glwindow->gesture()->confirmGesture();
-				}
-				setLauncherPosition(qMin(
-					1.0,
-					1.0 - (ev->points().first()
-							       .globalPosition()
-							       .y() /
-						       scaleFactor() -
-					       m_workspace->outputGeometry()
-						       .y()) /
-							m_workspace
-								->outputGeometry()
-								.height()));
-			}
+    if (edge == EDGE_TOP) {
+        if (launcherPosition() > 0.0) {
+            if (ev->isBeginEvent() || ev->isUpdateEvent()) {
+                if ((ev->points().first().globalPosition() -
+                     m_glwindow->gesture()->startingPoint())
+                        .y() > GESTURE_MINIMUM_THRESHOLD) {
+                    m_glwindow->gesture()->confirmGesture();
+                }
+                setLauncherPosition(qMin(
+                    1.0,
+                    1.0 - (ev->points().first()
+                                   .globalPosition()
+                                   .y() /
+                               scaleFactor() -
+                           m_workspace->outputGeometry()
+                               .y()) /
+                            m_workspace
+                                ->outputGeometry()
+                                .height()));
+            }
 
-			if (ev->isEndEvent()) {
-				if (ev->points().first().globalPosition().y() <
-				    m_glwindow->height() * 0.2)
-					launcherOpenAnim->start();
-				else
-					launcherCloseAnim->start();
-			}
-			return true;
-		}
-	}
+            if (ev->isEndEvent()) {
+                if (ev->points().first().globalPosition().y() <
+                    m_glwindow->height() * 0.2)
+                    launcherOpenAnim->start();
+                else
+                    launcherCloseAnim->start();
+            }
+            return true;
+        }
+    }
 
-	if (corner == CORNER_BR || corner == CORNER_BL) {
-		if (launcherPosition() > 0.0) {
-			return false;
-		}
+    if (corner == CORNER_BR || corner == CORNER_BL) {
+        if (launcherPosition() > 0.0) {
+            return false;
+        }
 
-		if (m_panelView != nullptr)
-			if (m_panelView->panelState > 1)
-				return false;
+        if (m_panelView != nullptr)
+            if (m_panelView->panelState > 1)
+                return false;
 
-		if (ev->isBeginEvent() || ev->isUpdateEvent()) {
-			if (m_inputMngr->getInputMethod() != nullptr)
-				if (!m_inputMngr->getInputMethod()
-					     ->isPanelHidden()) {
-					return false;
-				}
-			if ((-ev->points().first().globalPosition() +
-			     m_glwindow->gesture()->startingPoint())
-				    .y() > GESTURE_MINIMUM_THRESHOLD) {
-				m_glwindow->gesture()->confirmGesture();
-			}
-			return true;
-		}
+        if (ev->isBeginEvent() || ev->isUpdateEvent()) {
+            if (m_inputMngr->getInputMethod() != nullptr)
+                if (!m_inputMngr->getInputMethod()
+                         ->isPanelHidden()) {
+                    return false;
+                }
+            if ((-ev->points().first().globalPosition() +
+                 m_glwindow->gesture()->startingPoint())
+                    .y() > GESTURE_MINIMUM_THRESHOLD) {
+                m_glwindow->gesture()->confirmGesture();
+            }
+            return true;
+        }
 
-		if (ev->isEndEvent()) {
-			if (m_panelView != nullptr) {
-				if (m_panelView->panelState > 1) {
-					return false;
-				}
-			}
-			if (ev->points().first().globalPosition().y() <
-			    m_glwindow->height() * 0.8) {
-				m_inputMngr->getInputMethod()->showPanel();
-				return true;
-			}
-		}
-	}
+        if (ev->isEndEvent()) {
+            if (m_panelView != nullptr) {
+                if (m_panelView->panelState > 1) {
+                    return false;
+                }
+            }
+            if (ev->points().first().globalPosition().y() <
+                m_glwindow->height() * 0.8) {
+                m_inputMngr->getInputMethod()->showPanel();
+                return true;
+            }
+        }
+    }
 
-	return false;
+    return false;
 }
 
 void CwlCompositor::viewSurfaceDestroyed()
 {
-	CwlView *view = qobject_cast<CwlView *>(sender());
-	CwlView *parent = view->parentView();
+    CwlView *view = qobject_cast<CwlView *>(sender());
+    if (!view) return;
+    CwlView *parent = view->parentView();
 
-	if (parent != nullptr) {
-		if (!view->isPopup())
-			raise(parent);
-		else
-			view->getPopup()->sendPopupDone();
+    if (parent != nullptr) {
+        if (!view->isPopup())
+            raise(parent);
+        else
+            view->getPopup()->sendPopupDone();
 
-		parent->removeChildView(view);
-	} else if (view == m_launcherView) {
-		m_launcherView = nullptr;
-	} else {
-		m_workspace->removeView(view);
-	}
+        parent->removeChildView(view);
+    } else if (view == m_launcherView) {
+        m_launcherView = nullptr;
+    } else {
+        m_workspace->removeView(view);
+    }
 
-	delete view;
-	triggerRender();
+    delete view;
+    triggerRender();
 }
 
 void CwlCompositor::triggerRender()
 {
-	m_glwindow->requestUpdate();
+    m_glwindow->requestUpdate();
 }
 
 void CwlCompositor::onToplevelDamaged(CwlView *view)
 {
-	m_cutieshell->onThumbnailDamage(view);
+    m_cutieshell->onThumbnailDamage(view);
 }
 
 void CwlCompositor::startRender()
 {
-	QWaylandOutput *out = defaultOutput();
-	if (out)
-		out->frameStarted();
+    QWaylandOutput *out = defaultOutput();
+    if (out)
+        out->frameStarted();
 }
 
 void CwlCompositor::endRender()
 {
-	QWaylandOutput *out = defaultOutput();
-	if (out)
-		out->sendFrameCallbacks();
+    QWaylandOutput *out = defaultOutput();
+    if (out)
+        out->sendFrameCallbacks();
 }
 
 int CwlCompositor::scaleFactor()
 {
-	return m_scaleFactor;
+    return qMax(1, m_scaleFactor);
 }
 
 void CwlCompositor::setScaleFactor(int scale)
 {
-	if (m_scaleFactor == scale)
-		return;
-	m_scaleFactor = scale;
-	if (m_output)
-		m_output->setScaleFactor(m_scaleFactor);
-	emit scaleFactorChanged(m_scaleFactor);
+    int safeScale = qMax(1, scale);
+    if (m_scaleFactor == safeScale)
+        return;
+    m_scaleFactor = safeScale;
+    if (m_output)
+        m_output->setScaleFactor(m_scaleFactor);
+    emit scaleFactorChanged(m_scaleFactor);
 }
 
 GlWindow *CwlCompositor::glWindow()
 {
-	return m_glwindow;
+    return m_glwindow;
 }
 
 double CwlCompositor::blur()
 {
-	return m_blur;
+    return m_blur;
 }
 
 void CwlCompositor::setBlur(double blur)
 {
-	if (m_blur == blur)
-		return;
-	m_blur = blur;
-	emit blurChanged(m_blur);
+    if (m_blur == blur)
+        return;
+    m_blur = blur;
+    emit blurChanged(m_blur);
 }
 
 double CwlCompositor::launcherPosition()
 {
-	return m_launcherPosition;
+    return m_launcherPosition;
 }
 
 void CwlCompositor::setLauncherPosition(double position)
 {
-	if (m_launcherPosition == position)
-		return;
-	m_launcherPosition = position;
-	QPointF newPos = m_launcherView->getPosition();
-	newPos.setY((1.0 - m_launcherPosition) *
-			    m_workspace->outputGeometry().height() +
-		    m_workspace->outputGeometry().y());
-	if (newPos.y() < m_workspace->availableGeometry().y() -
-				 m_workspace->outputGeometry().y())
-		newPos.setY(m_workspace->availableGeometry().y() -
-			    m_workspace->outputGeometry().y());
-	if (m_homeOpen)
-		setBlur(m_launcherPosition);
-	m_launcherView->setPosition(newPos);
-	emit launcherPositionChanged(m_launcherPosition);
+    if (m_launcherPosition == position || !m_launcherView)
+        return;
+    m_launcherPosition = position;
+    QPointF newPos = m_launcherView->getPosition();
+    
+    // Safety check for workspace height to avoid division by zero or invalid positioning
+    double workspaceHeight = qMax(100.0, (double)m_workspace->outputGeometry().height());
+    
+    newPos.setY((1.0 - m_launcherPosition) * workspaceHeight + m_workspace->outputGeometry().y());
+    
+    if (newPos.y() < m_workspace->availableGeometry().y() - m_workspace->outputGeometry().y())
+        newPos.setY(m_workspace->availableGeometry().y() - m_workspace->outputGeometry().y());
+    
+    if (m_homeOpen)
+        setBlur(m_launcherPosition);
+    m_launcherView->setPosition(newPos);
+    emit launcherPositionChanged(m_launcherPosition);
 }
 
 ForeignToplevelManagerV1 *CwlCompositor::foreignTlManagerV1()
 {
-	return m_foreignTlManagerV1;
+    return m_foreignTlManagerV1;
 }
 
 void CwlCompositor::grabSurface(QWaylandSurfaceGrabber *grabber,
-				const QWaylandBufferRef &buffer)
+                const QWaylandBufferRef &buffer)
 {
-	if (buffer.isSharedMemory()) {
-		emit grabber->success(buffer.image());
-	} else {
-		if (QOpenGLContext::currentContext()) {
-			QOpenGLFramebufferObject fbo(buffer.size());
-			fbo.bind();
-			QOpenGLTextureBlitter blitter;
-			blitter.create();
+    if (buffer.isSharedMemory()) {
+        emit grabber->success(buffer.image());
+    } else {
+        if (QOpenGLContext::currentContext()) {
+            QOpenGLFramebufferObject fbo(buffer.size());
+            fbo.bind();
+            QOpenGLTextureBlitter blitter;
+            blitter.create();
 
-			glViewport(0, 0, buffer.size().width(),
-				   buffer.size().height());
-			glClearColor(0.f, 0.f, 0.f, 0.f);
-			glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            glViewport(0, 0, buffer.size().width(),
+                   buffer.size().height());
+            glClearColor(0.f, 0.f, 0.f, 0.f);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-			QOpenGLTextureBlitter::Origin surfaceOrigin =
-				buffer.origin() ==
-						QWaylandSurface::OriginTopLeft ?
-					QOpenGLTextureBlitter::OriginTopLeft :
-					QOpenGLTextureBlitter::OriginBottomLeft;
+            QOpenGLTextureBlitter::Origin surfaceOrigin =
+                buffer.origin() ==
+                        QWaylandSurface::OriginTopLeft ?
+                    QOpenGLTextureBlitter::OriginTopLeft :
+                    QOpenGLTextureBlitter::OriginBottomLeft;
 
-			auto texture = buffer.toOpenGLTexture();
-			blitter.bind(texture->target());
-			blitter.blit(texture->textureId(), QMatrix4x4(),
-				     surfaceOrigin);
-			blitter.release();
+            auto texture = buffer.toOpenGLTexture();
+            blitter.bind(texture->target());
+            blitter.blit(texture->textureId(), QMatrix4x4(),
+                     surfaceOrigin);
+            blitter.release();
 
-			emit grabber->success(fbo.toImage());
-		} else
-			emit grabber->failed(
-				QWaylandSurfaceGrabber::UnknownBufferType);
-	}
+            emit grabber->success(fbo.toImage());
+        } else
+            emit grabber->failed(
+                QWaylandSurfaceGrabber::UnknownBufferType);
+    }
 }

--- a/src/glwindow.cpp
+++ b/src/glwindow.cpp
@@ -5,204 +5,242 @@
 #include <QOpenGLFunctions>
 #include <QOpenGLTexture>
 #include <QMouseEvent>
+#include <QResizeEvent>
 #include <QGuiApplication>
 #include <qpa/qplatformnativeinterface.h>
 #include <qpa/qplatformscreen.h>
 #include <QtWaylandCompositor/QWaylandSeat>
+#include <QtWaylandCompositor/QWaylandOutputMode>
 
 GlWindow::GlWindow()
 {
-	QGuiApplication::platformNativeInterface()->nativeResourceForIntegration(
-		"displayon");
-	m_displayOff = false;
+    QGuiApplication::platformNativeInterface()->nativeResourceForIntegration(
+        "displayon");
+    m_displayOff = false;
 }
 
 void GlWindow::setCompositor(CwlCompositor *cwlcompositor)
 {
-	m_cwlcompositor = cwlcompositor;
-	if (m_gesture)
-		delete m_gesture;
-	m_gesture = new CwlGesture(cwlcompositor, QSize(width(), height()));
+    m_cwlcompositor = cwlcompositor;
+    if (m_gesture)
+        delete m_gesture;
+    
+    // Safety: ensure we don't pass 0,0 to the gesture handler
+    int w = width() > 0 ? width() : 720;
+    int h = height() > 0 ? height() : 1280;
+    m_gesture = new CwlGesture(cwlcompositor, QSize(w, h));
+}
+
+// --- Handle window resizing ---
+void GlWindow::resizeEvent(QResizeEvent *ev)
+{
+    QOpenGLWindow::resizeEvent(ev);
+    if (m_cwlcompositor && m_cwlcompositor->defaultOutput()) {
+        QSize newSize = ev->size();
+        if (newSize.width() > 0 && newSize.height() > 0) {
+            QWaylandOutputMode mode(newSize, 60000);
+            m_cwlcompositor->defaultOutput()->addMode(mode, true);
+            m_cwlcompositor->defaultOutput()->setCurrentMode(mode);
+            
+            // Re-sync gesture area to new size
+            if (m_gesture) {
+                delete m_gesture;
+                m_gesture = new CwlGesture(m_cwlcompositor, newSize);
+            }
+        }
+    }
 }
 
 bool GlWindow::displayOff()
 {
-	return m_displayOff;
+    return m_displayOff;
 }
 
 void GlWindow::setDisplayOff(bool displayOff)
 {
-	if (m_displayOff == displayOff)
-		return;
+    if (m_displayOff == displayOff)
+        return;
 
-	QGuiApplication::primaryScreen()->handle()->setPowerState(
-		displayOff ? QPlatformScreen::PowerStateOff :
-			     QPlatformScreen::PowerStateOn);
+    QGuiApplication::primaryScreen()->handle()->setPowerState(
+        displayOff ? QPlatformScreen::PowerStateOff :
+                 QPlatformScreen::PowerStateOn);
 
-	if (displayOff) {
-		m_cwlcompositor->setLauncherPosition(0.0);
-		m_cwlcompositor->onHideKeyboard();
-	} else
-		requestUpdate();
+    if (displayOff) {
+        if (m_cwlcompositor) {
+            m_cwlcompositor->setLauncherPosition(0.0);
+            m_cwlcompositor->onHideKeyboard();
+        }
+    } else
+        requestUpdate();
 
-	m_displayOff = displayOff;
-	emit displayOffChanged(m_displayOff);
+    m_displayOff = displayOff;
+    emit displayOffChanged(m_displayOff);
 }
 
 void GlWindow::initializeGL()
 {
-	m_textureBlitter.create();
-	emit glReady();
+    m_textureBlitter.create();
+    emit glReady();
 }
 
 void GlWindow::paintGL()
 {
-	if (m_displayOff)
-		return;
-	m_cwlcompositor->startRender();
+    if (m_displayOff || !m_cwlcompositor)
+        return;
+    m_cwlcompositor->startRender();
 
-	QOpenGLFunctions *functions = context()->functions();
-	functions->glClearColor(.0f, .0f, .0f, 1.f);
-	functions->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    QOpenGLFunctions *functions = context()->functions();
+    functions->glClearColor(.0f, .0f, .0f, 1.f);
+    functions->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-	m_currentTarget = GL_TEXTURE_2D;
-	m_textureBlitter.bind(m_currentTarget);
-	functions->glEnable(GL_BLEND);
-	functions->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    m_currentTarget = GL_TEXTURE_2D;
+    m_textureBlitter.bind(m_currentTarget);
+    functions->glEnable(GL_BLEND);
+    functions->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-	QList<CwlView *> renderViews;
-	if (m_cwlcompositor->m_launcherView)
-		renderViews = m_cwlcompositor->getViews()
-			      << m_cwlcompositor->m_launcherView;
-	else
-		renderViews = m_cwlcompositor->getViews();
+    QList<CwlView *> renderViews;
+    if (m_cwlcompositor->m_launcherView)
+        renderViews = m_cwlcompositor->getViews()
+                  << m_cwlcompositor->m_launcherView;
+    else
+        renderViews = m_cwlcompositor->getViews();
 
-	for (CwlView *view : renderViews) {
-		QString appId;
-		if (view && view->isToplevel())
-			appId = view->getAppId();
+    for (CwlView *view : renderViews) {
+        if (!view) continue; // Safety check
+        QString appId;
+        if (view->isToplevel())
+            appId = view->getAppId();
 
-		if (appId == "cutie-launcher")
-			m_textureBlitter.setOpacity(
-				1.0 -
-				(m_cwlcompositor->m_launcherView->getPosition()
-					 .y() *
-				 m_cwlcompositor->scaleFactor() / height()));
-		else if (view->isToplevel())
-			if (m_cwlcompositor->launcherPosition() > 0.0)
-				m_textureBlitter.setOpacity(
-					m_cwlcompositor->blur() *
-					m_cwlcompositor->m_launcherView
-						->getPosition()
-						.y() *
-					m_cwlcompositor->scaleFactor() /
-					height());
-			else
-				m_textureBlitter.setOpacity(
-					m_cwlcompositor->blur());
-		else
-			m_textureBlitter.setOpacity(1.0);
+        int winHeight = height() > 0 ? height() : 1280;
 
-		if (m_cwlcompositor->launcherPosition() == 1.0 &&
-		    view->layer == CwlViewLayer::TOP)
-			continue;
+        if (appId == "cutie-launcher")
+            m_textureBlitter.setOpacity(
+                1.0 -
+                (m_cwlcompositor->m_launcherView->getPosition()
+                     .y() *
+                 m_cwlcompositor->scaleFactor() / winHeight));
+        else if (view->isToplevel())
+            if (m_cwlcompositor->launcherPosition() > 0.0)
+                m_textureBlitter.setOpacity(
+                    m_cwlcompositor->blur() *
+                    m_cwlcompositor->m_launcherView
+                        ->getPosition()
+                        .y() *
+                    m_cwlcompositor->scaleFactor() /
+                    winHeight);
+            else
+                m_textureBlitter.setOpacity(
+                    m_cwlcompositor->blur());
+        else
+            m_textureBlitter.setOpacity(1.0);
 
-		renderView(view);
-	}
+        if (m_cwlcompositor->launcherPosition() == 1.0 &&
+            view->layer == CwlViewLayer::TOP)
+            continue;
 
-	m_textureBlitter.release();
-	m_cwlcompositor->endRender();
+        renderView(view);
+    }
+
+    m_textureBlitter.release();
+    m_cwlcompositor->endRender();
 }
 
 void GlWindow::renderView(CwlView *view)
 {
-	QOpenGLTexture *texture = view->getTexture();
-	if (!texture)
-		return;
-	if (texture->target() != m_currentTarget) {
-		m_currentTarget = texture->target();
-		m_textureBlitter.bind(m_currentTarget);
-	}
+    if (!view) return;
+    QOpenGLTexture *texture = view->getTexture();
+    if (!texture)
+        return;
+    if (texture->target() != m_currentTarget) {
+        m_currentTarget = texture->target();
+        m_textureBlitter.bind(m_currentTarget);
+    }
 
-	QWaylandSurface *surface = view->surface();
-	if (surface && surface->hasContent()) {
-		QSize viewSize = view->size();
-		QPointF viewPosition = view->getPosition();
-		auto surfaceOrigin = view->textureOrigin();
-		QRectF targetRect(viewPosition * m_cwlcompositor->scaleFactor(),
-				  viewSize * m_cwlcompositor->scaleFactor());
+    QWaylandSurface *surface = view->surface();
+    if (surface && surface->hasContent()) {
+        QSize viewSize = view->size();
+        QPointF viewPosition = view->getPosition();
+        auto surfaceOrigin = view->textureOrigin();
+        int scale = m_cwlcompositor->scaleFactor();
+        QRectF targetRect(viewPosition * scale, viewSize * scale);
 
-		QMatrix4x4 targetTransform =
-			QOpenGLTextureBlitter::targetTransform(
-				targetRect, QRect(QPoint(), size()));
-		m_textureBlitter.blit(texture->textureId(), targetTransform,
-				      surfaceOrigin);
-	}
+        QMatrix4x4 targetTransform =
+            QOpenGLTextureBlitter::targetTransform(
+                targetRect, QRect(QPoint(), size()));
+        m_textureBlitter.blit(texture->textureId(), targetTransform,
+                      surfaceOrigin);
+    }
 
-	if (view->getChildViews().size() > 0) {
-		for (CwlView *childView : view->getChildViews())
-			renderView(childView);
-	}
+    if (view->getChildViews().size() > 0) {
+        for (CwlView *childView : view->getChildViews())
+            renderView(childView);
+    }
 }
 
 void GlWindow::touchEvent(QTouchEvent *ev)
 {
-	m_gesture->handlePointerEvent(ev, [this](QList<QEventPoint> points) {
-		m_cwlcompositor->handleTouchEvent(points);
-	});
+    if (!m_gesture || !m_cwlcompositor) return;
+    m_gesture->handlePointerEvent(ev, [this](QList<QEventPoint> points) {
+        m_cwlcompositor->handleTouchEvent(points);
+    });
 }
 
 void GlWindow::mouseMoveEvent(QMouseEvent *ev)
 {
-	m_gesture->handlePointerEvent(ev, [this](QList<QEventPoint> points) {
-		m_cwlcompositor->handleMouseMoveEvent(points);
-	});
+    if (!m_gesture || !m_cwlcompositor) return;
+    m_gesture->handlePointerEvent(ev, [this](QList<QEventPoint> points) {
+        m_cwlcompositor->handleMouseMoveEvent(points);
+    });
 }
 
 void GlWindow::mousePressEvent(QMouseEvent *ev)
 {
-	Qt::MouseButton btn = ev->button();
-	m_gesture->handlePointerEvent(ev, [this,
-					   btn](QList<QEventPoint> points) {
-		m_cwlcompositor->handleMousePressEvent(points, btn);
-	});
+    if (!m_gesture || !m_cwlcompositor) return;
+    Qt::MouseButton btn = ev->button();
+    m_gesture->handlePointerEvent(ev, [this,
+                       btn](QList<QEventPoint> points) {
+        m_cwlcompositor->handleMousePressEvent(points, btn);
+    });
 }
 
 void GlWindow::mouseReleaseEvent(QMouseEvent *ev)
 {
-	Qt::MouseButton btn = ev->button();
-	m_gesture->handlePointerEvent(ev, [this,
-					   btn](QList<QEventPoint> points) {
-		m_cwlcompositor->handleMouseReleaseEvent(points, btn);
-	});
+    if (!m_gesture || !m_cwlcompositor) return;
+    Qt::MouseButton btn = ev->button();
+    m_gesture->handlePointerEvent(ev, [this,
+                       btn](QList<QEventPoint> points) {
+        m_cwlcompositor->handleMouseReleaseEvent(points, btn);
+    });
 }
 
 void GlWindow::keyPressEvent(QKeyEvent *event)
 {
-	if (event->key() == Qt::Key_PowerOff)
-		m_cwlcompositor->specialKey(
-			CutieShell::SpecialKey::POWER_PRESS);
+    if (!m_cwlcompositor) return;
+    if (event->key() == Qt::Key_PowerOff)
+        m_cwlcompositor->specialKey(
+            CutieShell::SpecialKey::POWER_PRESS);
 
-	if (event->key() == Qt::Key_VolumeUp)
-		m_cwlcompositor->specialKey(
-			CutieShell::SpecialKey::VOLUME_UP_PRESS);
+    if (event->key() == Qt::Key_VolumeUp)
+        m_cwlcompositor->specialKey(
+            CutieShell::SpecialKey::VOLUME_UP_PRESS);
 
-	if (event->key() == Qt::Key_VolumeDown)
-		m_cwlcompositor->specialKey(
-			CutieShell::SpecialKey::VOLUME_DOWN_PRESS);		
+    if (event->key() == Qt::Key_VolumeDown)
+        m_cwlcompositor->specialKey(
+            CutieShell::SpecialKey::VOLUME_DOWN_PRESS);     
 }
 
 void GlWindow::keyReleaseEvent(QKeyEvent *event)
 {
-	if (event->key() == Qt::Key_PowerOff)
-		m_cwlcompositor->specialKey(
-			CutieShell::SpecialKey::POWER_RELEASE);
+    if (!m_cwlcompositor) return;
+    if (event->key() == Qt::Key_PowerOff)
+        m_cwlcompositor->specialKey(
+            CutieShell::SpecialKey::POWER_RELEASE);
 
-	if (event->key() == Qt::Key_VolumeUp)
-		m_cwlcompositor->specialKey(
-			CutieShell::SpecialKey::VOLUME_UP_RELEASE);
+    if (event->key() == Qt::Key_VolumeUp)
+        m_cwlcompositor->specialKey(
+            CutieShell::SpecialKey::VOLUME_UP_RELEASE);
 
-	if (event->key() == Qt::Key_VolumeDown)
-		m_cwlcompositor->specialKey(
-			CutieShell::SpecialKey::VOLUME_DOWN_RELEASE);
+    if (event->key() == Qt::Key_VolumeDown)
+        m_cwlcompositor->specialKey(
+            CutieShell::SpecialKey::VOLUME_DOWN_RELEASE);
 }

--- a/src/glwindow.h
+++ b/src/glwindow.h
@@ -3,6 +3,7 @@
 #include <QOpenGLWindow>
 #include <QOpenGLTextureBlitter>
 #include <QEventPoint>
+#include <QResizeEvent> // Added for resizeEvent support
 
 #include <cutie-wlc.h>
 #include <gesture.h>
@@ -10,44 +11,48 @@
 QT_BEGIN_NAMESPACE
 
 class GlWindow : public QOpenGLWindow {
-	Q_OBJECT
+    Q_OBJECT
     public:
-	GlWindow();
-	void setCompositor(CwlCompositor *cwlcompositor);
-	bool displayOff();
-	void setDisplayOff(bool displayOff);
-	inline CwlGesture *gesture()
-	{
-		return m_gesture;
-	}
+    GlWindow();
+    void setCompositor(CwlCompositor *cwlcompositor);
+    bool displayOff();
+    void setDisplayOff(bool displayOff);
+    inline CwlGesture *gesture()
+    {
+        return m_gesture;
+    }
 
     signals:
-	void glReady();
-	void displayOffChanged(bool displayOff);
+    void glReady();
+    void displayOffChanged(bool displayOff);
 
     protected:
-	void initializeGL() override;
-	void paintGL() override;
+    void initializeGL() override;
+    void paintGL() override;
 
-	void touchEvent(QTouchEvent *ev) override;
-	void mouseMoveEvent(QMouseEvent *ev) override;
-	void mousePressEvent(QMouseEvent *ev) override;
-	void mouseReleaseEvent(QMouseEvent *ev) override;
-	void keyPressEvent(QKeyEvent *event) override;
-	void keyReleaseEvent(QKeyEvent *event) override;
+    // --- MINIMAL FIX: Added declaration ---
+    void resizeEvent(QResizeEvent *ev) override;
+    // --------------------------------------
+
+    void touchEvent(QTouchEvent *ev) override;
+    void mouseMoveEvent(QMouseEvent *ev) override;
+    void mousePressEvent(QMouseEvent *ev) override;
+    void mouseReleaseEvent(QMouseEvent *ev) override;
+    void keyPressEvent(QKeyEvent *event) override;
+    void keyReleaseEvent(QKeyEvent *event) override;
 
     private:
-	void renderView(CwlView *view);
+    void renderView(CwlView *view);
 
-	QOpenGLTextureBlitter m_textureBlitter;
-	GLenum m_currentTarget;
-	QOpenGLTexture *m_wallpaper = nullptr;
+    QOpenGLTextureBlitter m_textureBlitter;
+    GLenum m_currentTarget;
+    QOpenGLTexture *m_wallpaper = nullptr;
 
-	QList<QEventPoint *> m_evPoint;
-	bool m_displayOff = false;
+    QList<QEventPoint *> m_evPoint;
+    bool m_displayOff = false;
 
-	CwlCompositor *m_cwlcompositor = nullptr;
-	CwlGesture *m_gesture = nullptr;
+    CwlCompositor *m_cwlcompositor = nullptr;
+    CwlGesture *m_gesture = nullptr;
 };
 
 QT_END_NAMESPACE


### PR DESCRIPTION
currently, when running in ubuntu the composer reports scale factor and dimensions as zero which crashes cutie shell components . this pr adds a default fall back to handle that situation 

- Added a 720x1280 fallback in CwlCompositor::create() to prevent initial geometry being reported as 0x0.
- Implemented GlWindow::resizeEvent to synchronize the Wayland  output mode with the physical window size.
- Added scale factor guards to ensure m_scaleFactor is never 0,  preventing "division by zero" protocol crashes in clients.
- Improved stability with null-pointer checks in event handlers.