### PR TITLE
performance: do not update thumbnail when cutie-home is not open

### DIFF
--- a/src/cutie-wlc.cpp
+++ b/src/cutie-wlc.cpp
@@ -590,6 +590,9 @@ void CwlCompositor::triggerRender()
 
 void CwlCompositor::onToplevelDamaged(CwlView *view)
 {
+	if (!m_homeOpen)
+        return;
+
 	m_cutieshell->onThumbnailDamage(view);
 }
 


### PR DESCRIPTION
App preview/thumbnail generation was running continuously in the background, causing severe performance hit and UI slowdowns. This ensures previews are only refreshed when the cutie-home is actively visible.